### PR TITLE
Removed nullptr access from Timer().hasStarted()

### DIFF
--- a/clients/roscpp/include/ros/timer.h
+++ b/clients/roscpp/include/ros/timer.h
@@ -71,7 +71,7 @@ public:
    */
   void setPeriod(const Duration& period, bool reset=true);
 
-  bool hasStarted() const { return impl_->hasStarted(); }
+  bool hasStarted() const { return impl_ && impl_->hasStarted(); }
   bool isValid() { return impl_ && impl_->isValid(); }
   operator void*() { return isValid() ? (void*)1 : (void*)0; }
 


### PR DESCRIPTION
### Description

This is a combo bug report and resolution.

Currently calling `hasStarted()` for a timer which hasn't been initialized properly just results in `nullptr` access. I added a short-circuit to prevent that from occurring.

### Scope

This change needs to be backported to Kinetic and Lunar (being maintained as of now). Doesn't affect Indigo

### Details

The reported error post crash is:
```
/usr/include/boost/smart_ptr/shared_ptr.hpp:648: typename boost::detail::sp_member_access<T>::type boost::shared_ptr<T>::operator->() const [with T = ros::Timer::Impl; typename boost::detail::sp_member_access<T>::type = ros::Timer::Impl*]: Assertion `px != 0' failed.
```